### PR TITLE
Don't use uppercase only in QR codes

### DIFF
--- a/girder_sample_tracker/models/sample.py
+++ b/girder_sample_tracker/models/sample.py
@@ -76,7 +76,7 @@ class Sample(AccessControlledModel):
     def qr_code(self, sample, url):
         buf = io.BytesIO()
         qr = qrcode.QRCode(
-            version=6,
+            version=8,
             error_correction=qrcode.constants.ERROR_CORRECT_H,
             border=10,
             image_factory=SvgPathFillImage,

--- a/girder_sample_tracker/web_client/views/SampleView.js
+++ b/girder_sample_tracker/web_client/views/SampleView.js
@@ -14,7 +14,7 @@ const { restRequest } = girder.rest;
 
 const QRparams = {
   'errorCorrectionLevel': 'H',
-  'version': 6,
+  'version': 8,
   'mode': 'alphanumeric',
 }
 
@@ -87,7 +87,7 @@ var SampleView = View.extend({
             DATE_MINUTE: DATE_MINUTE
         }));
         const addEventUrl = `${window.location.origin}/#sample/${this.model.id}/add`;
-        QRCode.toCanvas(this.$('#g-sample-qr')[0], addEventUrl.toUpperCase(), QRparams);
+        QRCode.toCanvas(this.$('#g-sample-qr')[0], addEventUrl, QRparams);
         if (this.addEvent) {
             this.addEventDialog();
         }


### PR DESCRIPTION
This pull request updates the QR code generation logic in both the backend and frontend to improve compatibility and readability. The most significant changes include increasing the QR code version and modifying the URL handling in the frontend.

### QR Code Updates:

* [`girder_sample_tracker/models/sample.py`](diffhunk://#diff-4bea5f543c65e1f17686babc5dfc216cc4a865634e91896a837b464d2342d2ffL79-R79): Increased the QR code version from 6 to 8 to allow for more data and better error correction.
* [`girder_sample_tracker/web_client/views/SampleView.js`](diffhunk://#diff-e3aef6e9842bbd3d1e27685ec3c155c402a010aa9cec6260a4ac2952c6b13083L17-R17): Updated the QR code version in the frontend configuration from 6 to 8 to match the backend changes.

### URL Handling:

* [`girder_sample_tracker/web_client/views/SampleView.js`](diffhunk://#diff-e3aef6e9842bbd3d1e27685ec3c155c402a010aa9cec6260a4ac2952c6b13083L90-R90): Removed the `.toUpperCase()` transformation on the `addEventUrl` when generating the QR code to preserve the original case of the URL.